### PR TITLE
Add support for ssh-agent or pageant.exe identities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,17 @@
             <version>2.1</version>
         </dependency>
 
+        <!-- support for ssh-agent and pageant.exe -->
+        <dependency>
+            <groupId>com.jcraft</groupId>
+            <artifactId>jsch.agentproxy.connector-factory</artifactId>
+            <version>0.0.9</version>
+        </dependency>
+        <dependency>
+            <groupId>com.jcraft</groupId>
+            <artifactId>jsch.agentproxy.jsch</artifactId>
+            <version>0.0.9</version>
+        </dependency>
 
         <!--All the test scoped dependencies are found below -->
         <!--TestNG is required because its our test runner -->
@@ -76,8 +87,7 @@
             <version>1.3.0</version>
             <scope>test</scope>
         </dependency>
-
-    </dependencies>
+   </dependencies>
     <build>
         <plugins>
             <plugin>

--- a/src/main/java/com/rationaleemotions/pojo/PasswordlessEnabledUser.java
+++ b/src/main/java/com/rationaleemotions/pojo/PasswordlessEnabledUser.java
@@ -16,6 +16,7 @@ public class PasswordlessEnabledUser implements UserInfo {
     public PasswordlessEnabledUser(String passphrase) {
         this.passphrase = passphrase;
     }
+
     @Override
     public String getPassphrase() {
         return passphrase;

--- a/src/main/java/com/rationaleemotions/pojo/SSHUser.java
+++ b/src/main/java/com/rationaleemotions/pojo/SSHUser.java
@@ -16,6 +16,7 @@ public class SSHUser {
     private File sshFolder;
     private File privateKey;
     private String passphrase;
+    private boolean useAgentIdentities = false;
 
     private SSHUser() {
         //We have a builder to construct this object. So hide the constructor.
@@ -55,6 +56,13 @@ public class SSHUser {
 
     public String getPassphrase() {
         return passphrase;
+    }
+
+    /**
+     * @return - Whether to use identities available via ssh-agent or pageant.exe
+     */
+    public boolean isUseAgentIdentities() {
+        return useAgentIdentities;
     }
 
     /**
@@ -112,6 +120,16 @@ public class SSHUser {
          */
         public Builder usingPassphrase(String passphrase) {
             this.user.passphrase = passphrase;
+            return this;
+        }
+
+        /**
+         * @param useAgentIdentities - <b>true</b> or <b>false</b>. Enable/Disable the ability to use
+         * credentials available via ssh-agent or pageant.exe. Disabled by default.
+         * @return
+         */
+        public Builder usingAgentIdentities(boolean useAgentIdentities) {
+            this.user.useAgentIdentities = useAgentIdentities;
             return this;
         }
 


### PR DESCRIPTION
This allows one to have their private key credentials managed by `ssh-agent` or `pageant.exe` (windows) and connect via this library.

Tests were intentionally left out due to the dependency on the two binaries when setting up credentials and/or making connections. If you want to assume that a *nix machine will have `ssh-agent` and a windows machine will have `pageant.exe` installed, I can add a test that spawns the appropriate application as a `@Before` condition.